### PR TITLE
Subcut code review

### DIFF
--- a/app/Global.scala
+++ b/app/Global.scala
@@ -1,4 +1,5 @@
-import com.escalatesoft.subcut.inject.{BindingModule, Injectable, BindingId, NewBindingModule}
+import com.escalatesoft.subcut.inject._
+import config.StandardConfiguration
 import play.api.GlobalSettings
 import services.{TextGenerator, WelcomeTextGenerator}
 
@@ -7,16 +8,8 @@ import services.{TextGenerator, WelcomeTextGenerator}
  */
 object Global extends GlobalSettings {
 
-  import NewBindingModule._
-
   object Context extends Injectable {
-    implicit val bindingModule : BindingModule = newBindingModule {
-      module =>
-        import module._
-
-        bind[TextGenerator] toSingle new WelcomeTextGenerator
-        bind[controllers.Application] toSingle new controllers.Application
-    }
+    implicit val bindingModule = StandardConfiguration  // use the standard config by default
 
     val application = inject[controllers.Application]
     val applicationClass = classOf[controllers.Application]

--- a/app/config/StandardConfiguration.scala
+++ b/app/config/StandardConfiguration.scala
@@ -1,0 +1,20 @@
+package config
+
+import com.escalatesoft.subcut.inject._
+import services.{WelcomeTextGenerator, TextGenerator}
+
+/**
+ * Created with IntelliJ IDEA.
+ * User: dick
+ * Date: 7/3/13
+ * Time: 1:52 PM
+ * Standard configuration for subcut
+ */
+object StandardConfiguration extends NewBindingModule({ module =>
+  import module._
+
+  bind [TextGenerator] toSingle new WelcomeTextGenerator
+
+  // controllers.Application is itself injectable, so we need the toModuleSingle form to pay the config forward
+  bind [controllers.Application] toModuleSingle { implicit module => new controllers.Application }
+})

--- a/app/controllers/Application.scala
+++ b/app/controllers/Application.scala
@@ -1,7 +1,7 @@
 package controllers
 
 import play.api.mvc._
-import services.TextGenerator
+import services.{WelcomeTextGenerator, TextGenerator}
 import com.escalatesoft.subcut.inject.{BindingModule, Injectable}
 
 /**
@@ -10,7 +10,8 @@ import com.escalatesoft.subcut.inject.{BindingModule, Injectable}
  */
 class Application(implicit val bindingModule: BindingModule) extends Controller with Injectable {
 
-  val textGenerator = inject[TextGenerator]
+  // injectOptional provides safe interception of bindings, but falling back on a default implementation otherwise
+  val textGenerator = injectOptional [TextGenerator] getOrElse new WelcomeTextGenerator
 
   def index = Action {
     Ok(views.html.index(textGenerator.welcomeText))

--- a/app/services/TextGenerator.scala
+++ b/app/services/TextGenerator.scala
@@ -1,14 +1,11 @@
 package services
 
-import com.escalatesoft.subcut.inject.{BindingModule, Injectable}
-
 /**
  * A type declaring the interface that will be injectable.
  */
 abstract class TextGenerator(val welcomeText: String)
 
 /**
- * A simple implementation of TextGenerator that we will inject.
+ * A standard implementation of TextGenerator that we will inject.
  */
-class WelcomeTextGenerator(implicit val bindingModule: BindingModule)
-  extends TextGenerator("Your new application is ready.") with Injectable
+class WelcomeTextGenerator extends TextGenerator("Your new application is ready.")


### PR DESCRIPTION
Hi Chris

Feel free to take a look and use these changes or not. What you had would work, but probably used inject[] more than it needed to (it's usual to separate the binding module from the injectable, i.e. not to have inject inside the binding module or the place where the binding module is defined - think of one as the producer and one as the consumer - things are clearer (I think) when they are kept separate.

I created a StandardConfiguration module since that is what people generally use this for, and then simplified the test by just modifying those bindings inline - it's much quicker than creating a new binding module for testing, although if you use the same alterations in a bunch of tests you still might want to create a TestModule that can be reused.
